### PR TITLE
Missing SEO Meta <title> tag on the product detail view

### DIFF
--- a/src/Plugin/Product/View.php
+++ b/src/Plugin/Product/View.php
@@ -93,8 +93,11 @@ class View
         } catch (LocalizedException $e) {
             return $result;
         }
-
-        $resultPage->getConfig()->getTitle()->set($product->getName());
+        
+        $pageMainTitle = $resultPage->getLayout()->getBlock('page.main.title');
+        if ($pageMainTitle) {
+            $pageMainTitle->setPageTitle($product->getName());
+        }
 
         if(null == $product->getCategory() || null == $product->getCategory()->getPath()){
             $breadcrumbsBlock->addCrumb(


### PR DESCRIPTION
On the product detail view instead the meta title tag from Product the Product Name is displayed. I've removed override the <title> and add override the main title. Beucase without those lines in main title also the meta <title> is shown