### PR TITLE
#5 Fix wrong order of categories

### DIFF
--- a/src/Plugin/Product/View.php
+++ b/src/Plugin/Product/View.php
@@ -93,7 +93,7 @@ class View
         } catch (LocalizedException $e) {
             return $result;
         }
-        
+
         $pageMainTitle = $resultPage->getLayout()->getBlock('page.main.title');
         if ($pageMainTitle) {
             $pageMainTitle->setPageTitle($product->getName());
@@ -111,12 +111,12 @@ class View
         }
 
         $categories = $product->getCategory()->getPath();
-        $categoriesids = explode('/', $categories);
+        $categoriesIds = explode('/', $categories);
 
         $categoriesCollection = null;
         try {
             $categoriesCollection = $this->collection
-                ->addFieldToFilter('entity_id', array('in' => $categoriesids))
+                ->addFieldToFilter('entity_id', array('in' => $categoriesIds))
                 ->addAttributeToSelect('name')
                 ->addAttributeToSelect('url_key')
                 ->addAttributeToSelect('include_in_menu')
@@ -126,8 +126,9 @@ class View
             return $result;
         }
 
-        foreach ($categoriesCollection->getItems() as $category) {
-            if ($category->getIsActive() && $category->isInRootCategoryList()) {
+        foreach ($categoriesIds as $categoryId) {
+            $category = $categoriesCollection->getItemById($categoryId);
+            if ($category && $category->getIsActive() && $category->isInRootCategoryList()) {
                 $categoryId = $category->getId();
                 $path = [
                     'label' => $category->getName(),


### PR DESCRIPTION
## Issue description:

Example: If the main category has ID 9 and the subcategory ID 6, appears in the product:
Home -> Subcategory -> Main Category -> Product Name

The exact position of the breadcrumb instead must be:
Home-> Main Category -> Subcategory -> Product Name

The issue occurs when the parent category has a higher entity_id than it child - then the child is loaded first and is displayed first in breadcrumbs.

## Code explanation

Instead of iterating over the categories collection which is sorted by ids by default, I iterate over the categories path and manually load each category from the collection to ensure that the order of categories in breadcrumbs is correct.

